### PR TITLE
Fix path bug

### DIFF
--- a/src/fragment-strategy/SubstringFragmentStrategy.ts
+++ b/src/fragment-strategy/SubstringFragmentStrategy.ts
@@ -109,7 +109,7 @@ class SubstringFragmentStrategy implements IFragmentStrategy {
     storage: string,
   ): Promise<void> {
     const predicate = bucket === 'root' ? 'https://w3id.org/tree#view' : 'http://rdfs.org/ns/void#subset';
-    const bucketFilePath = `${storage}/${bucket}.ttl`;
+    const bucketFilePath = `${bucket}.ttl`;
 
     const quad = this.factory.quad(
       this.factory.namedNode(collectionUri),


### PR DESCRIPTION
Fix bug in relative path as this was currently returned: 
`<https://smartdata.dev-vlaanderen.be/base/gemeente> <https://w3id.org/tree#view> <https://ddvlanck.github.io/Republish-LDES/gemeente-substrings/gemeente-substrings/root.ttl>.` 
and 
`<https://smartdata.dev-vlaanderen.be/base/gemeente> <http://rdfs.org/ns/void#subset> <https://ddvlanck.github.io/Republish-LDES/gemeente-substrings/gemeente-substrings/a.ttl>.`

This pull request doens’t repeat the storage folder any more so the relative URI will start from the last `/`